### PR TITLE
fix:online url for rosetta-cli conf

### DIFF
--- a/rosetta-cli-conf/zen_mainnet.json
+++ b/rosetta-cli-conf/zen_mainnet.json
@@ -3,6 +3,7 @@
   "blockchain": "Zen",
   "network": "main"
  },
+ "online_url": "http://127.0.0.1:8080",
  "data_directory": "zen-mainnet-data",
  "http_timeout": 300,
  "max_retries": 5,

--- a/rosetta-cli-conf/zen_testnet.json
+++ b/rosetta-cli-conf/zen_testnet.json
@@ -3,7 +3,7 @@
    "blockchain": "Zen",
    "network": "test"
  },
- "online_url": "http://127.0.0.1:8081",
+ "online_url": "http://127.0.0.1:8080",
  "data_directory": "zen-testnet-data",
  "http_timeout": 300,
  "max_retries": 5,


### PR DESCRIPTION
These changes are needed to run the rosetta-cli tests against the docker containers created via makefile. 